### PR TITLE
fix(v11): update styles for textarea

### DIFF
--- a/packages/carbon-web-components/src/components/textarea/textarea.scss
+++ b/packages/carbon-web-components/src/components/textarea/textarea.scss
@@ -7,7 +7,7 @@
 
 $css--plex: true !default;
 @use '@carbon/styles/scss/config' as *;
-@use '@carbon/styles/scss/components/text-area/text-area';
+@use '@carbon/styles/scss/components/text-area/index';
 
 :host(#{$prefix}-textarea) {
   outline: none;


### PR DESCRIPTION
### Related Ticket(s)

[Component]: textarea [#10013](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10013)

### Description

`textarea` styles are off, importing the `index` file corrects this

### Changelog

**Changed**

- import textarea `index` style file instead

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
