### PR TITLE
fix(list): update ordered and unordered list

### DIFF
--- a/packages/carbon-web-components/src/components/checkbox/checkbox-story.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-story.ts
@@ -14,6 +14,7 @@ import textNullable from '../../../.storybook/knob-text-nullable';
 import ifNonNull from '../../globals/directives/if-non-null';
 import './checkbox';
 import storyDocs from './checkbox-story.mdx';
+import { prefix } from '../../globals/settings';
 
 export const Default = (args) => {
   const {
@@ -27,15 +28,27 @@ export const Default = (args) => {
     onChange,
   } = args?.['bx-checkbox'] ?? {};
   return html`
-    <cds-checkbox
-      ?checked="${checked}"
-      ?disabled="${disabled}"
-      ?hide-label="${hideLabel}"
-      ?indeterminate="${indeterminate}"
-      label-text="${ifNonNull(labelText)}"
-      name="${ifNonNull(name)}"
-      value="${ifNonNull(value)}"
-      @bx-checkbox-changed="${onChange}"></cds-checkbox>
+    <fieldset class="${prefix}--fieldset">
+      <legend class="${prefix}--label">Group label</legend>
+      <cds-checkbox
+        ?checked="${checked}"
+        ?disabled="${disabled}"
+        ?hide-label="${hideLabel}"
+        ?indeterminate="${indeterminate}"
+        label-text="${ifNonNull(labelText)}"
+        name="${ifNonNull(name)}"
+        value="${ifNonNull(value)}"
+        @bx-checkbox-changed="${onChange}"></cds-checkbox>
+      <cds-checkbox
+        ?checked="${checked}"
+        ?disabled="${disabled}"
+        ?hide-label="${hideLabel}"
+        ?indeterminate="${indeterminate}"
+        label-text="${ifNonNull(labelText)}"
+        name="${ifNonNull(name)}"
+        value="${ifNonNull(value)}"
+        @bx-checkbox-changed="${onChange}"></cds-checkbox>
+    </fieldset>
   `;
 };
 

--- a/packages/carbon-web-components/src/components/checkbox/checkbox-story.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox-story.ts
@@ -26,7 +26,7 @@ export const Default = (args) => {
     name,
     value,
     onChange,
-  } = args?.['bx-checkbox'] ?? {};
+  } = args?.[`${prefix}-checkbox`] ?? {};
   return html`
     <fieldset class="${prefix}--fieldset">
       <legend class="${prefix}--label">Group label</legend>
@@ -59,7 +59,7 @@ export default {
   parameters: {
     ...storyDocs.parameters,
     knobs: {
-      'bx-checkbox': () => ({
+      [`${prefix}-checkbox`]: () => ({
         checked: boolean('Checked (checked)', false),
         disabled: boolean('Disabled (disabled)', false),
         hideLabel: boolean('Hide label (hide-label)', false),

--- a/packages/carbon-web-components/src/components/checkbox/checkbox.ts
+++ b/packages/carbon-web-components/src/components/checkbox/checkbox.ts
@@ -18,8 +18,8 @@ import styles from './checkbox.scss';
 /**
  * Check box.
  *
- * @element bx-checkbox
- * @fires bx-checkbox-changed - The custom event fired after this changebox changes its checked state.
+ * @element cds-checkbox
+ * @fires cds-checkbox-changed - The custom event fired after this changebox changes its checked state.
  * @csspart input The checkbox.
  * @csspart label The label.
  */

--- a/packages/carbon-web-components/src/components/list/list-story.ts
+++ b/packages/carbon-web-components/src/components/list/list-story.ts
@@ -15,16 +15,16 @@ import { boolean } from '@storybook/addon-knobs';
 import storyDocs from './list-story.mdx';
 
 export const ordered = (args) => {
-  const { isExpressive } = args?.['bx-list'] ?? {};
+  const { isExpressive, native } = args?.['cds-list'] ?? {};
   return html`
-    <cds-ordered-list ?isExpressive="${isExpressive}">
+    <cds-ordered-list ?isExpressive="${isExpressive}" ?native="${native}">
       <cds-list-item>
         Ordered List level 1
-        <cds-ordered-list ?isExpressive="${isExpressive}">
+        <cds-ordered-list ?isExpressive="${isExpressive}" ?native="${native}">
           <cds-list-item>Ordered List level 2</cds-list-item>
           <cds-list-item>
             Ordered List level 2
-            <cds-ordered-list ?isExpressive="${isExpressive}">
+            <cds-ordered-list ?isExpressive="${isExpressive}" ?native="${native}">
               <cds-list-item>Ordered List level 2</cds-list-item>
               <cds-list-item>Ordered List level 2</cds-list-item>
             </cds-ordered-list>
@@ -33,12 +33,23 @@ export const ordered = (args) => {
       </cds-list-item>
       <cds-list-item>Ordered List level 1</cds-list-item>
       <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
+      <cds-list-item>Ordered List level 1</cds-list-item>
     </cds-ordered-list>
+  </cds-ordered-list>
   `;
 };
 
 export const unordered = (args) => {
-  const { isExpressive } = args?.['bx-list'] ?? {};
+  const { isExpressive } = args?.['cds-list'] ?? {};
   return html`
     <cds-unordered-list ?isExpressive="${isExpressive}">
       <cds-list-item>
@@ -65,8 +76,9 @@ export default {
   parameters: {
     ...storyDocs.parameters,
     knobs: {
-      'bx-list': () => ({
+      'cds-list': () => ({
         isExpressive: boolean('Expressive (isExpressive)', false),
+        native: boolean('Native (native)', false),
       }),
     },
   },

--- a/packages/carbon-web-components/src/components/list/list.scss
+++ b/packages/carbon-web-components/src/components/list/list.scss
@@ -15,11 +15,12 @@ $css--plex: true !default;
 
 :host(#{$prefix}-ordered-list),
 :host(#{$prefix}-unordered-list) {
-  display: block;
-  padding-left: $spacing-06;
-
   .#{$prefix}--list--nested {
-    margin-left: 0;
+    margin-left: rem(32px);
+  }
+
+  .#{$prefix}--list--nested ::slotted(#{$prefix}-list-item) {
+    padding-left: $spacing-02;
   }
 }
 
@@ -62,7 +63,7 @@ $css--plex: true !default;
 
   &::before {
     position: absolute;
-    left: -$spacing-05;
+    left: calc(-1 * #{$spacing-05});
     // – en dash
     content: '\002013';
   }
@@ -71,7 +72,7 @@ $css--plex: true !default;
 :host(#{$prefix}-unordered-list[slot='nested'])
   ::slotted(#{$prefix}-list-item)::before {
   // offset to account for smaller ▪ vs –
-  left: -$spacing-04;
+  left: calc(-1 * #{$spacing-04});
   // ▪ square
   content: '\0025AA';
 }

--- a/packages/carbon-web-components/src/components/list/list.scss
+++ b/packages/carbon-web-components/src/components/list/list.scss
@@ -10,6 +10,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/components/list';
 
 :host(#{$prefix}-ordered-list),
@@ -22,16 +23,30 @@ $css--plex: true !default;
   }
 }
 
+// ordered list
 :host(#{$prefix}-ordered-list) {
-  .#{$prefix}--list--ordered {
-    list-style-type: decimal;
-  }
-
   .#{$prefix}--list--ordered.#{$prefix}--list--nested {
     list-style-type: lower-latin;
   }
+
+  &:not(.#{$prefix}--list--nested) {
+    counter-reset: item;
+  }
+
+  &:not(.#{$prefix}--list--nested) ::slotted(#{$prefix}-list-item) {
+    position: relative;
+  }
+
+  .#{$prefix}--list--ordered:not(.#{$prefix}--list--nested)
+    ::slotted(#{$prefix}-list-item)::before {
+    position: absolute;
+    left: rem(-24px);
+    content: counter(item) '.';
+    counter-increment: item;
+  }
 }
 
+// unordered list
 :host(#{$prefix}-unordered-list) {
   // – en dash
   --#{$prefix}-ce--list-marker: '\002013';

--- a/packages/carbon-web-components/src/components/list/ordered-list-story.ts
+++ b/packages/carbon-web-components/src/components/list/ordered-list-story.ts
@@ -9,12 +9,11 @@
 
 import { html } from 'lit-element';
 import './ordered-list';
-import './unordered-list';
 import './list-item';
 import { boolean } from '@storybook/addon-knobs';
 import storyDocs from './list-story.mdx';
 
-export const ordered = (args) => {
+export const Default = (args) => {
   const { isExpressive, native } = args?.['cds-list'] ?? {};
   return html`
     <cds-ordered-list ?isExpressive="${isExpressive}" ?native="${native}">
@@ -48,31 +47,10 @@ export const ordered = (args) => {
   `;
 };
 
-export const unordered = (args) => {
-  const { isExpressive } = args?.['cds-list'] ?? {};
-  return html`
-    <cds-unordered-list ?isExpressive="${isExpressive}">
-      <cds-list-item>
-        Unordered List level 1
-        <cds-unordered-list ?isExpressive="${isExpressive}">
-          <cds-list-item>Unordered List level 2</cds-list-item>
-          <cds-list-item>
-            Unordered List level 2
-            <cds-unordered-list ?isExpressive="${isExpressive}">
-              <cds-list-item>Unordered List level 2</cds-list-item>
-              <cds-list-item>Unordered List level 2</cds-list-item>
-            </cds-unordered-list>
-          </cds-list-item>
-        </cds-unordered-list>
-      </cds-list-item>
-      <cds-list-item>Unordered List level 1</cds-list-item>
-      <cds-list-item>Unordered List level 1</cds-list-item>
-    </cds-unordered-list>
-  `;
-};
+Default.storyName = 'Default';
 
 export default {
-  title: 'Components/List',
+  title: 'Components/Ordered List',
   parameters: {
     ...storyDocs.parameters,
     knobs: {

--- a/packages/carbon-web-components/src/components/list/ordered-list.ts
+++ b/packages/carbon-web-components/src/components/list/ordered-list.ts
@@ -8,7 +8,7 @@
  */
 
 import { classMap } from 'lit-html/directives/class-map';
-import { html, customElement } from 'lit-element';
+import { html, customElement, property } from 'lit-element';
 import { prefix } from '../../globals/settings';
 import BXUnorderedList from './unordered-list';
 
@@ -17,9 +17,17 @@ import BXUnorderedList from './unordered-list';
  */
 @customElement(`${prefix}-ordered-list`)
 class BXOrderedList extends BXUnorderedList {
+  /**
+   * Specify whether the ordered list should use native list styles instead of
+   * custom counter
+   */
+  @property({ type: Boolean, reflect: true })
+  native = false;
+
   render() {
     const classes = classMap({
-      [`${prefix}--list--ordered`]: true,
+      [`${prefix}--list--ordered`]: !this.native,
+      [`${prefix}--list--ordered--native`]: this.native,
       [`${prefix}--list--nested`]: this.getAttribute('slot') === 'nested',
       [`${prefix}--list--expressive`]: this.isExpressive,
     });

--- a/packages/carbon-web-components/src/components/list/unordered-list-story.ts
+++ b/packages/carbon-web-components/src/components/list/unordered-list-story.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html } from 'lit-element';
+import './unordered-list';
+import './list-item';
+import { boolean } from '@storybook/addon-knobs';
+import storyDocs from './list-story.mdx';
+
+export const Default = (args) => {
+  const { isExpressive } = args?.['cds-list'] ?? {};
+  return html`
+    <cds-unordered-list ?isExpressive="${isExpressive}">
+      <cds-list-item>
+        Unordered List level 1
+        <cds-unordered-list ?isExpressive="${isExpressive}">
+          <cds-list-item>Unordered List level 2</cds-list-item>
+          <cds-list-item>
+            Unordered List level 2
+            <cds-unordered-list ?isExpressive="${isExpressive}">
+              <cds-list-item>Unordered List level 2</cds-list-item>
+              <cds-list-item>Unordered List level 2</cds-list-item>
+            </cds-unordered-list>
+          </cds-list-item>
+        </cds-unordered-list>
+      </cds-list-item>
+      <cds-list-item>Unordered List level 1</cds-list-item>
+      <cds-list-item>Unordered List level 1</cds-list-item>
+    </cds-unordered-list>
+  `;
+};
+
+Default.storyName = 'Default';
+
+export default {
+  title: 'Components/Unordered List',
+  parameters: {
+    ...storyDocs.parameters,
+    knobs: {
+      'cds-list': () => ({
+        isExpressive: boolean('Expressive (isExpressive)', false),
+      }),
+    },
+  },
+};


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9993

### Description

This PR updates the list component to use Carbon v11 styles. The ordered and unordered list stories are separated now, and the ordered list now has `native` styling options in line with v11

### Changelog

**New**

- ordered list `native` property

**Changed**

- separate ordered and unordered list stories

**Removed**

- combined list story

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
