### PR TITLE
fix(progress-indicator): update styles and icons to v11 spec

### DIFF
--- a/packages/carbon-web-components/src/components/progress-indicator/defs.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -12,9 +12,9 @@
  */
 export enum PROGRESS_STEP_STAT {
   /**
-   * One for future execution.
+   * Complete one.
    */
-  QUEUED = 'queued',
+  COMPLETE = 'complete',
 
   /**
    * One that is being executed now.
@@ -22,9 +22,9 @@ export enum PROGRESS_STEP_STAT {
   CURRENT = 'current',
 
   /**
-   * Complete one.
+   * One for future execution.
    */
-  COMPLETE = 'complete',
+  INCOMPLETE = 'incomplete',
 
   /**
    * Invalid one.

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator-story.ts
@@ -19,38 +19,32 @@ import storyDocs from './progress-indicator-story.mdx';
 
 export const Default = (args) => {
   const { vertical } = args?.['bx-progress-indicator'] ?? {};
-  const { iconLabel, labelText, secondaryLabelText } =
-    args?.['bx-progress-step'] ?? {};
+  const { iconLabel, secondaryLabelText } = args?.['bx-progress-step'] ?? {};
   return html`
     <cds-progress-indicator ?vertical="${vertical}">
       <cds-progress-step
         icon-label="${ifNonNull(iconLabel)}"
-        label-text="${ifNonNull(labelText)}"
-        secondary-label-text="${ifNonNull(secondaryLabelText)}"
-        state="invalid"></cds-progress-step>
-      <cds-progress-step
-        icon-label="${ifNonNull(iconLabel)}"
-        label-text="${ifNonNull(labelText)}"
+        label-text="First step"
         secondary-label-text="${ifNonNull(secondaryLabelText)}"
         state="complete"></cds-progress-step>
       <cds-progress-step
         icon-label="${ifNonNull(iconLabel)}"
-        label-text="${ifNonNull(labelText)}"
-        secondary-label-text="${ifNonNull(secondaryLabelText)}"
+        label-text="Second step with tooltip"
         state="current"></cds-progress-step>
+      <cds-progress-step
+        icon-label="${ifNonNull(iconLabel)}"
+        label-text="Third step with tooltip"
+        state="incomplete"></cds-progress-step>
+      <cds-progress-step
+        icon-label="${ifNonNull(iconLabel)}"
+        label-text="Fourth step"
+        secondary-label-text="Example invalid step"
+        state="invalid"></cds-progress-step>
       <cds-progress-step
         disabled
         icon-label="${ifNonNull(iconLabel)}"
-        label-text="${ifNonNull(labelText)}"
-        secondary-label-text="${ifNonNull(
-          secondaryLabelText
-        )}"></cds-progress-step>
-      <cds-progress-step
-        icon-label="${ifNonNull(iconLabel)}"
-        label-text="${ifNonNull(labelText)}"
-        secondary-label-text="${ifNonNull(
-          secondaryLabelText
-        )}"></cds-progress-step>
+        label-text="Fifth step"
+        state="incomplete"></cds-progress-step>
     </cds-progress-indicator>
   `;
 };
@@ -64,7 +58,6 @@ Default.parameters = {
     }),
     'bx-progress-step': () => ({
       iconLabel: textNullable('Icon label (icon-label)', ''),
-      labelText: textNullable('Primary label text (label-text)', 'Label'),
       secondaryLabelText: textNullable(
         'Secondary label text (secondary-label-text)',
         'Secondary label'

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-indicator.scss
@@ -8,6 +8,7 @@
 $css--plex: true !default;
 
 @use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/utilities/skeleton' as *;
 @use '@carbon/styles/scss/components/progress-indicator/progress-indicator' as *;
@@ -47,7 +48,7 @@ $css--plex: true !default;
 :host(#{$prefix}-progress-step[vertical]),
 :host(#{$prefix}-progress-step-skeleton[vertical]) {
   display: list-item;
-  min-height: 6rem;
+  min-height: $spacing-12;
   width: initial;
   min-width: initial;
 
@@ -89,6 +90,10 @@ $css--plex: true !default;
 
 :host(#{$prefix}-progress-step[state='current']) {
   @extend .#{$prefix}--progress-step--current;
+
+  svg {
+    fill: $interactive;
+  }
 }
 
 :host(#{$prefix}-progress-step[state='complete']) {
@@ -97,6 +102,10 @@ $css--plex: true !default;
   svg {
     fill: $interactive;
   }
+}
+
+:host(#{$prefix}-progress-step[state='incomplete']) {
+  @extend .#{$prefix}--progress-step--incomplete;
 }
 
 :host(#{$prefix}-progress-step-skeleton) .#{$prefix}--progress-label {

--- a/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
+++ b/packages/carbon-web-components/src/components/progress-indicator/progress-step.ts
@@ -7,12 +7,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { SVGTemplateResult } from 'lit-html';
 import { html, svg, property, customElement, LitElement } from 'lit-element';
 import CheckmarkOutline16 from '@carbon/icons/lib/checkmark--outline/16';
+import CircleDash16 from '@carbon/icons/lib/circle-dash/16';
+import Incomplete16 from '@carbon/icons/lib/incomplete/16';
 import Warning16 from '@carbon/icons/lib/warning/16';
 import { prefix } from '../../globals/settings';
-import spread from '../../globals/directives/spread';
 import FocusMixin from '../../globals/mixins/focus';
 import { PROGRESS_STEP_STAT } from './defs';
 import styles from './progress-indicator.scss';
@@ -23,34 +23,10 @@ export { PROGRESS_STEP_STAT };
  * Icons, keyed by state.
  */
 const icons = {
-  [PROGRESS_STEP_STAT.QUEUED]: ({
-    children,
-    attrs = {},
-  }: {
-    children?: SVGTemplateResult;
-    attrs?: { [key: string]: string };
-  } = {}) =>
-    svg`
-      <svg ...="${spread(attrs)}">
-        ${children}
-        <path d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z" />
-      </svg>
-    `,
-  [PROGRESS_STEP_STAT.CURRENT]: ({
-    children,
-    attrs = {},
-  }: {
-    children?: SVGTemplateResult;
-    attrs?: { [key: string]: string };
-  } = {}) =>
-    svg`
-      <svg ...="${spread(attrs)}">
-        ${children}
-        <path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" />
-      </svg>
-    `,
   [PROGRESS_STEP_STAT.COMPLETE]: CheckmarkOutline16,
+  [PROGRESS_STEP_STAT.INCOMPLETE]: CircleDash16,
   [PROGRESS_STEP_STAT.INVALID]: Warning16,
+  [PROGRESS_STEP_STAT.CURRENT]: Incomplete16,
 };
 
 /**


### PR DESCRIPTION
### Related Ticket(s)

#10001

### Description

Updates `progress-indicator` to match v11 styles and icons.

### Changelog

- {{new thing}}

**Changed**

- use available icons from `@carbon/icons`
- update story to match Carbon React v11

**Removed**

- custom icon svg

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
