### PR TITLE
fix(modal): update modal styles

### DIFF
--- a/packages/carbon-web-components/src/components/modal/modal-story.ts
+++ b/packages/carbon-web-components/src/components/modal/modal-story.ts
@@ -31,8 +31,8 @@ const sizes = {
 };
 
 export const Default = (args) => {
-  const { open, size, disableClose, onBeforeClose, onClose } =
-    args?.['bx-modal'] ?? {};
+  const { danger, open, size, disableClose, onBeforeClose, onClose } =
+    args?.['cds-modal'] ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
     if (disableClose) {
@@ -43,8 +43,8 @@ export const Default = (args) => {
     <cds-modal
       ?open="${open}"
       size="${ifNonNull(size)}"
-      @bx-modal-beingclosed=${handleBeforeClose}
-      @bx-modal-closed=${onClose}>
+      @cds-modal-beingclosed=${handleBeforeClose}
+      @cds-modal-closed=${onClose}>
       <cds-modal-header>
         <cds-modal-close-button></cds-modal-close-button>
         <cds-modal-label>Label (Optional)</cds-modal-label>
@@ -55,7 +55,9 @@ export const Default = (args) => {
         <cds-modal-footer-button kind="secondary" data-modal-close
           >Cancel</cds-modal-footer-button
         >
-        <cds-modal-footer-button kind="primary">Save</cds-modal-footer-button>
+        <cds-modal-footer-button kind="${danger ? 'danger' : 'primary'}"
+          >Save</cds-modal-footer-button
+        >
       </cds-modal-footer>
     </cds-modal>
   `;
@@ -64,8 +66,8 @@ export const Default = (args) => {
 Default.storyName = 'Default';
 
 export const SingleButton = (args) => {
-  const { open, size, disableClose, onBeforeClose, onClose } =
-    args?.['bx-modal'] ?? {};
+  const { danger, open, size, disableClose, onBeforeClose, onClose } =
+    args?.['cds-modal'] ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
     if (disableClose) {
@@ -76,8 +78,8 @@ export const SingleButton = (args) => {
     <cds-modal
       ?open="${open}"
       size="${ifNonNull(size)}"
-      @bx-modal-beingclosed=${handleBeforeClose}
-      @bx-modal-closed=${onClose}>
+      @cds-modal-beingclosed=${handleBeforeClose}
+      @cds-modal-closed=${onClose}>
       <cds-modal-header>
         <cds-modal-close-button></cds-modal-close-button>
         <cds-modal-label>Label (Optional)</cds-modal-label>
@@ -85,7 +87,9 @@ export const SingleButton = (args) => {
       </cds-modal-header>
       <cds-modal-body><p>Modal text description</p></cds-modal-body>
       <cds-modal-footer>
-        <cds-modal-footer-button kind="primary">Save</cds-modal-footer-button>
+        <cds-modal-footer-button kind="${danger ? 'danger' : 'primary'}"
+          >Save</cds-modal-footer-button
+        >
       </cds-modal-footer>
     </cds-modal>
   `;
@@ -94,8 +98,8 @@ export const SingleButton = (args) => {
 SingleButton.storyName = 'Single button';
 
 export const ThreeButtons = (args) => {
-  const { open, size, disableClose, onBeforeClose, onClose } =
-    args?.['bx-modal'] ?? {};
+  const { danger, open, size, disableClose, onBeforeClose, onClose } =
+    args?.['cds-modal'] ?? {};
   const handleBeforeClose = (event: CustomEvent) => {
     onBeforeClose(event);
     if (disableClose) {
@@ -106,8 +110,8 @@ export const ThreeButtons = (args) => {
     <cds-modal
       ?open="${open}"
       size="${ifNonNull(size)}"
-      @bx-modal-beingclosed=${handleBeforeClose}
-      @bx-modal-closed=${onClose}>
+      @cds-modal-beingclosed=${handleBeforeClose}
+      @cds-modal-closed=${onClose}>
       <cds-modal-header>
         <cds-modal-close-button></cds-modal-close-button>
         <cds-modal-label>Label (Optional)</cds-modal-label>
@@ -121,7 +125,9 @@ export const ThreeButtons = (args) => {
         <cds-modal-footer-button kind="secondary" data-modal-close
           >Cancel</cds-modal-footer-button
         >
-        <cds-modal-footer-button kind="primary">Save</cds-modal-footer-button>
+        <cds-modal-footer-button kind="${danger ? 'danger' : 'primary'}"
+          >Save</cds-modal-footer-button
+        >
       </cds-modal-footer>
     </cds-modal>
   `;
@@ -142,16 +148,16 @@ export default {
   parameters: {
     ...storyDocs.parameters,
     knobs: {
-      'bx-modal': () => ({
+      'cds-modal': () => ({
         open: boolean('Open (open)', true),
         danger: boolean('Danger mode (danger)', false),
         disableClose: boolean(
-          'Disable user-initiated close action (Call event.preventDefault() in bx-modal-beingclosed event)',
+          'Disable user-initiated close action (Call event.preventDefault() in cds-modal-beingclosed event)',
           false
         ),
         size: select('Modal size (size)', sizes, null),
-        onBeforeClose: action('bx-modal-beingclosed'),
-        onClose: action('bx-modal-closed'),
+        onBeforeClose: action('cds-modal-beingclosed'),
+        onClose: action('cds-modal-closed'),
       }),
     },
   },

--- a/packages/carbon-web-components/src/components/modal/modal.scss
+++ b/packages/carbon-web-components/src/components/modal/modal.scss
@@ -10,6 +10,7 @@
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/breakpoint' as *;
+@use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/components/modal';
 @use '@carbon/styles/scss/components/button' as *;
 
@@ -118,10 +119,12 @@
 
 :host(#{$prefix}-modal-footer) ::slotted(#{$prefix}-btn),
 :host(#{$prefix}-modal-footer-button) {
+  flex: 0 1 50%;
   max-width: none;
   width: 50%;
   height: rem(64px);
   margin: 0;
+  padding-bottom: $spacing-07;
 }
 
 :host(#{$prefix}-modal-footer-button) .#{$prefix}--btn {

--- a/packages/carbon-web-components/src/components/modal/modal.ts
+++ b/packages/carbon-web-components/src/components/modal/modal.ts
@@ -59,12 +59,12 @@ function tryFocusElems(
 /**
  * Modal.
  *
- * @element bx-modal
+ * @element cds-modal
  * @csspart dialog The dialog.
- * @fires bx-modal-beingclosed
+ * @fires cds-modal-beingclosed
  *   The custom event fired before this modal is being closed upon a user gesture.
  *   Cancellation of this event stops the user-initiated action of closing this modal.
- * @fires bx-modal-closed - The custom event fired after this modal is closed upon a user gesture.
+ * @fires cds-modal-closed - The custom event fired after this modal is closed upon a user gesture.
  */
 @customElement(`${prefix}-modal`)
 class BXModal extends HostListenerMixin(LitElement) {
@@ -268,8 +268,8 @@ class BXModal extends HostListenerMixin(LitElement) {
         );
         await (this.constructor as typeof BXModal)._delay();
         if (primaryFocusNode) {
-          // For cases where a `carbon-web-components` component (e.g. `<bx-btn>`) being `primaryFocusNode`,
-          // where its first update/render cycle that makes it focusable happens after `<bx-modal>`'s first update/render cycle
+          // For cases where a `carbon-web-components` component (e.g. `<cds-btn>`) being `primaryFocusNode`,
+          // where its first update/render cycle that makes it focusable happens after `<cds-modal>`'s first update/render cycle
           (primaryFocusNode as HTMLElement).focus();
         } else if (
           !tryFocusElems(


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9995

### Description

This PR updates the modal to use the Carbon v11 prefix and danger modal styles

### Changelog

**New**

- danger modal styles

**Changed**

- v11 prefix

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
