### PR TITLE
fix(breadcrumb): missing slashes

### DIFF
--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-story.ts
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb-story.ts
@@ -12,6 +12,7 @@ import './breadcrumb';
 import './breadcrumb-item';
 import './breadcrumb-link';
 import './breadcrumb-overflow-menu';
+import '../overflow-menu/overflow-menu-body';
 import storyDocs from './breadcrumb-story.mdx';
 
 export const Default = () =>

--- a/packages/carbon-web-components/src/components/breadcrumb/breadcrumb.scss
+++ b/packages/carbon-web-components/src/components/breadcrumb/breadcrumb.scss
@@ -10,7 +10,7 @@ $css--plex: true !default;
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/motion' as *;
-// @use '@carbon/styles/scss/components/link';
+@use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/components/breadcrumb';
 @import '../overflow-menu/overflow-menu';
 

--- a/packages/carbon-web-components/src/components/overflow-menu/overflow-menu.scss
+++ b/packages/carbon-web-components/src/components/overflow-menu/overflow-menu.scss
@@ -59,23 +59,11 @@ $css--plex: true !default;
 
 :host(#{$prefix}-overflow-menu-body) {
   @extend .#{$prefix}--overflow-menu-options;
-
-  &::after {
-    @extend .#{$prefix}--overflow-menu-options,
-      [data-floating-menu-direction='bottom'],
-      ::after;
-  }
 }
 
 :host(#{$prefix}-overflow-menu-body[direction='top']) {
   margin-top: 0;
   margin-bottom: $spacing-02;
-
-  &::after {
-    @extend .#{$prefix}--overflow-menu-options,
-      [data-floating-menu-direction='top'],
-      ::after;
-  }
 }
 
 :host(#{$prefix}-overflow-menu-body[open]) {


### PR DESCRIPTION
### Related Ticket(s)

# 9978
### Description

update breadcrumb styles with v11
### Changelog

**New**

- story missing overflow-menu-body import
- added missing utilities convert for `rem()`

**Removed**

- the overflow styles were causing the slashes to not appear and removing them seemed to not have any affect on the overflow depending on the direction

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
