### PR TITLE
fix(accoridion): update styles with new props

### DIFF
--- a/packages/carbon-web-components/.storybook/_container.scss
+++ b/packages/carbon-web-components/.storybook/_container.scss
@@ -12,7 +12,15 @@
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/themes' as *;
 
-@use '@carbon/styles/scss/reset';
+@import '@carbon/type/scss/type';
+@import '@carbon/type/scss/font-face/mono';
+@import '@carbon/type/scss/font-face/sans';
+@import '@carbon/type/scss/font-face/serif';
+
+@include carbon--type-reset();
+@include carbon--font-face-mono();
+@include carbon--font-face-sans();
+@include carbon--font-face-serif();
 
 // The default theme is "white" (White)
 :root {

--- a/packages/carbon-web-components/src/components/accordion/accordion-story.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-story.ts
@@ -32,8 +32,7 @@ export const Default = (args) => {
     onToggle = noop,
     size,
     alignment,
-    isFlush,
-    className,
+    isFlush
   } = args?.['bx-accordion'] ?? {};
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
@@ -48,8 +47,7 @@ export const Default = (args) => {
       @bx-accordion-item-toggled="${onToggle}"
       size="${size}"
       alignment="${alignment}"
-      ?isFlush="${isFlush}"
-      className="${className}">
+      ?isFlush="${isFlush}">
       <cds-accordion-item
         ?disabled="${disabled}"
         ?open="${open}"

--- a/packages/carbon-web-components/src/components/accordion/accordion-story.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion-story.ts
@@ -15,9 +15,9 @@ import './accordion-item';
 import storyDocs from './accordion-story.mdx';
 
 const sizes = {
-  'Regular size': null,
   [`Small size (${ACCORDION_SIZE.SMALL})`]: ACCORDION_SIZE.SMALL,
-  [`XL size (${ACCORDION_SIZE.EXTRA_LARGE})`]: ACCORDION_SIZE.EXTRA_LARGE,
+  [`Medium size (${ACCORDION_SIZE.MEDIUM})`]: ACCORDION_SIZE.MEDIUM,
+  [`Large size (${ACCORDION_SIZE.LARGE})`]: ACCORDION_SIZE.LARGE,
 };
 
 const noop = () => {};
@@ -31,6 +31,9 @@ export const Default = (args) => {
     onBeforeToggle = noop,
     onToggle = noop,
     size,
+    alignment,
+    isFlush,
+    className,
   } = args?.['bx-accordion'] ?? {};
   const handleBeforeToggle = (event: CustomEvent) => {
     onBeforeToggle(event);
@@ -43,7 +46,10 @@ export const Default = (args) => {
     <cds-accordion
       @bx-accordion-item-beingtoggled="${handleBeforeToggle}"
       @bx-accordion-item-toggled="${onToggle}"
-      size="${size}">
+      size="${size}"
+      alignment="${alignment}"
+      ?isFlush="${isFlush}"
+      className="${className}">
       <cds-accordion-item
         ?disabled="${disabled}"
         ?open="${open}"
@@ -87,6 +93,12 @@ export default {
         open: boolean('Open the section (open)', false),
         titleText: text('The title (title-text)', 'Section title'),
         size: select('Accordion size (size)', sizes, null),
+        alignment: select(
+          'Accordion alignment (alignment)',
+          ['start', 'end'],
+          'end'
+        ),
+        isFlush: boolean('isFlush', false),
         disabled: boolean('Disable accordion item (disabled)', false),
         disableToggle: boolean(
           'Disable user-initiated toggle action (Call event.preventDefault() in bx-accordion-beingtoggled event)',

--- a/packages/carbon-web-components/src/components/accordion/accordion.scss
+++ b/packages/carbon-web-components/src/components/accordion/accordion.scss
@@ -30,17 +30,28 @@ $css--plex: true !default;
     min-height: $spacing-08;
   }
 
-  &[size='sm'] {
-    .#{$prefix}--accordion__heading {
-      min-height: rem(32px);
-      padding: rem(5px) 0;
+  .#{$prefix}--accordion__content {
+    @extend .#{$prefix}--accordion__content;
+
+    ::slotted(p) {
+      @include type-style('body-01');
     }
   }
 
-  &[size='xl'] {
-    .#{$prefix}--accordion__heading {
-      min-height: rem(48px);
-    }
+  &[size='sm'] {
+    @extend .#{$prefix}--accordion--sm;
+  }
+
+  &[size='lg'] {
+    @extend .#{$prefix}--accordion--lg;
+  }
+
+  &[alignment='start'] {
+    @extend .#{$prefix}--accordion--start;
+  }
+
+  &[isFlush] {
+    @extend .#{$prefix}--accordion--flush;
   }
 }
 

--- a/packages/carbon-web-components/src/components/accordion/accordion.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion.ts
@@ -10,10 +10,10 @@
 import { html, property, customElement, LitElement } from 'lit-element';
 import { prefix } from '../../globals/settings';
 import { forEach } from '../../globals/internal/collection-helpers';
-import { ACCORDION_SIZE } from './defs';
+import { ACCORDION_SIZE, ACCORDION_ALIGNMENT } from './defs';
 import styles from './accordion.scss';
 
-export { ACCORDION_SIZE };
+export { ACCORDION_SIZE, ACCORDION_ALIGNMENT };
 
 /**
  * Accordion container.
@@ -23,10 +23,28 @@ export { ACCORDION_SIZE };
 @customElement(`${prefix}-accordion`)
 class BXAccordion extends LitElement {
   /**
-   * Accordion size.
+   * Accordion size should be sm, md, lg.
    */
   @property({ reflect: true })
-  size = ACCORDION_SIZE.REGULAR;
+  size = ACCORDION_SIZE.MEDIUM;
+
+  /**
+   * Specify the alignment of the accordion heading title and chevron
+   */
+  @property({ reflect: true })
+  alignment = ACCORDION_ALIGNMENT.END;
+
+  /**
+   * Specify whether Accordion text should be flush, default is false, does not work with align="start"
+   */
+  @property({ type: Boolean, reflect: true })
+  isFlush = false;
+
+  /**
+   * Specify an optional className to be applied to the container node
+   */
+  @property({ type: String, reflect: true })
+  className = '';
 
   connectedCallback() {
     if (!this.hasAttribute('role')) {
@@ -44,6 +62,33 @@ class BXAccordion extends LitElement {
         ),
         (elem) => {
           elem.setAttribute('size', this.size);
+        }
+      );
+    }
+    if (changedProperties.has('alignment')) {
+      // Propagate `alignment` attribute to descendants until `:host-context()` gets supported in all major browsers
+      forEach(
+        this.querySelectorAll(
+          (this.constructor as typeof BXAccordion).selectorAccordionItems
+        ),
+        (elem) => {
+          elem.setAttribute('alignment', this.alignment);
+        }
+      );
+    }
+    if (
+      changedProperties.has('isFlush') ||
+      changedProperties.has('alignment')
+    ) {
+      // Propagate `isFlush` attribute to descendants until `:host-context()` gets supported in all major browsers
+      forEach(
+        this.querySelectorAll(
+          (this.constructor as typeof BXAccordion).selectorAccordionItems
+        ),
+        (elem) => {
+          this.isFlush && this.alignment !== 'start'
+            ? elem.setAttribute('isFlush', '')
+            : elem.removeAttribute('isFlush');
         }
       );
     }

--- a/packages/carbon-web-components/src/components/accordion/accordion.ts
+++ b/packages/carbon-web-components/src/components/accordion/accordion.ts
@@ -40,12 +40,6 @@ class BXAccordion extends LitElement {
   @property({ type: Boolean, reflect: true })
   isFlush = false;
 
-  /**
-   * Specify an optional className to be applied to the container node
-   */
-  @property({ type: String, reflect: true })
-  className = '';
-
   connectedCallback() {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'list');

--- a/packages/carbon-web-components/src/components/accordion/defs.ts
+++ b/packages/carbon-web-components/src/components/accordion/defs.ts
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2020
+ * Copyright IBM Corp. 2020, 2023
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -23,21 +23,36 @@ export enum ACCORDION_ITEM_BREAKPOINT {
 }
 
 /**
- * Button size.
+ * Accordion size.
  */
 export enum ACCORDION_SIZE {
-  /**
-   * Regular size.
-   */
-  REGULAR = '',
-
   /**
    * Small size.
    */
   SMALL = 'sm',
 
   /**
-   * X-Large size.
+   * Medium size.
    */
-  EXTRA_LARGE = 'xl',
+  MEDIUM = 'md',
+
+  /**
+   * Large size.
+   */
+  LARGE = 'lg',
+}
+
+/**
+ * Specify the alignment of the accordion heading title and chevron.
+ */
+export enum ACCORDION_ALIGNMENT {
+  /**
+   * Alignment to the start
+   */
+  START = 'start',
+
+  /**
+   * Alignment to the end
+   */
+  END = 'END',
 }


### PR DESCRIPTION
### Related Ticket(s)

### Description

update props and styles to match v11 accordion
also update storybook container styles, so the accordion `p` don't get overriden 
### Changelog

**New**

- props in accordion
- add accordion styles

**Changed**

- instead of using reset for the container styles import the different type fonts

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
