### PR TITLE
chore(copy-button): update styles for copy-button

### DIFF
--- a/packages/carbon-web-components/src/components/copy-button/copy-button.scss
+++ b/packages/carbon-web-components/src/components/copy-button/copy-button.scss
@@ -8,15 +8,9 @@
 $css--plex: true !default;
 
 @use '@carbon/styles/scss/config' as *;
-@use '@carbon/styles/scss/components/code-snippet/code-snippet';
-@use '@carbon/styles/scss/components/copy-button/copy-button';
+@use '@carbon/styles/scss/components/copy-button/index';
 
 :host(#{$prefix}-copy-button) {
   display: inline-flex;
   outline: none;
-
-  .#{$prefix}--snippet-button .#{$prefix}--btn--copy__feedback {
-    left: 50%;
-    right: auto;
-  }
 }

--- a/packages/carbon-web-components/src/components/copy-button/copy-button.ts
+++ b/packages/carbon-web-components/src/components/copy-button/copy-button.ts
@@ -49,8 +49,8 @@ export const _createHandleFeedbackTooltip = (
 export const _renderButton = ({
   assistiveText,
   feedbackText,
-  showFeedback = false,
-  className = `${prefix}--snippet-button`,
+  showFeedback = true,
+  className = `${prefix}--copy-btn`,
   children = html`
     <slot>${Copy16({ class: `${prefix}--snippet__icon` })}</slot>
   `,
@@ -65,7 +65,8 @@ export const _renderButton = ({
 }) => {
   const feedbackClasses = classMap({
     [`${prefix}--btn--copy__feedback`]: true,
-    [`${prefix}--btn--copy__feedback--displayed`]: showFeedback,
+    [`${prefix}--assistive-text`]: true,
+    [`${prefix}--copy-btn--animating`]: showFeedback,
   });
   return html`
     <button
@@ -74,9 +75,7 @@ export const _renderButton = ({
       title="${ifDefined(assistiveText)}"
       @click="${handleClickButton}">
       ${children}
-      <div
-        class="${feedbackClasses}"
-        data-feedback="${ifDefined(feedbackText)}"></div>
+      <span class="${feedbackClasses}">${feedbackText}</span>
     </button>
   `;
 };

--- a/packages/carbon-web-components/src/components/copy-button/copy-button.ts
+++ b/packages/carbon-web-components/src/components/copy-button/copy-button.ts
@@ -49,7 +49,7 @@ export const _createHandleFeedbackTooltip = (
 export const _renderButton = ({
   assistiveText,
   feedbackText,
-  showFeedback = true,
+  showFeedback = false,
   className = `${prefix}--copy-btn`,
   children = html`
     <slot>${Copy16({ class: `${prefix}--snippet__icon` })}</slot>
@@ -75,7 +75,9 @@ export const _renderButton = ({
       title="${ifDefined(assistiveText)}"
       @click="${handleClickButton}">
       ${children}
-      <span class="${feedbackClasses}">${feedbackText}</span>
+      <div
+        class="${feedbackClasses}"
+        data-feedback="${ifDefined(feedbackText)}"></div>
     </button>
   `;
 };


### PR DESCRIPTION
### Related Ticket(s)

[Component]: copy-button #9984

### Description

Imports and aligns the copy button style and classes. Still needs to be restructured a bit to ensure the tooltip appears

### Changelog

**Changed**

- classnames to match new ones in v11
- import `index` of copy-button styles.

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
