### PR TITLE
fix(combo-box): include assistive utility

### DIFF
--- a/packages/carbon-web-components/src/components/combo-box/combo-box.scss
+++ b/packages/carbon-web-components/src/components/combo-box/combo-box.scss
@@ -9,6 +9,7 @@ $css--plex: true !default;
 
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/utilities' as *;
 @use '@carbon/styles/scss/components/combo-box/combo-box';
 @use '@carbon/styles/scss/components/form';
 @use '@carbon/styles/scss/components/text-input/text-input';


### PR DESCRIPTION
### Related Ticket(s)

[#9982
](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9982)
### Description

combo box missing utilities in styles for converting rem and visually-hidden

### Changelog

**New**

- add missing utility in styles


<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
