### PR TITLE
chore(v11): update number-input styles

### DIFF
--- a/packages/carbon-web-components/src/components/number-input/number-input.scss
+++ b/packages/carbon-web-components/src/components/number-input/number-input.scss
@@ -8,7 +8,8 @@
 $css--plex: true !default;
 
 @use '@carbon/styles/scss/config' as *;
-@use '@carbon/styles/scss/components/number-input/number-input';
+@use '@carbon/styles/scss/components/form';
+@use '@carbon/styles/scss/components/number-input/index';
 
 :host(#{$prefix}-number-input),
 :host(#{$prefix}-number-input-skeleton) {


### PR DESCRIPTION
### Related Ticket(s)

[Component]: number-input #9998

### Description

Update styles import with `number-input` index file and the `form` styles

BEFORE:
<img width="260" alt="Screen Shot 2023-02-21 at 11 57 14 AM" src="https://user-images.githubusercontent.com/54281166/220412968-2aadfe4b-6ead-409a-8357-8d85086870d9.png">

AFTER:
<img width="276" alt="Screen Shot 2023-02-21 at 11 57 29 AM" src="https://user-images.githubusercontent.com/54281166/220412986-8681f922-0d6a-4fe0-abbe-55c118fd24de.png">

### Changelog

**Changed**

- add `form` styles needed for the input's label styles
- import the `index` style file instead

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
