### PR TITLE
fix(components): file uploader, tabs, and input styles

### DIFF
--- a/packages/carbon-web-components/src/components/file-uploader/demo-file-uploader.ts
+++ b/packages/carbon-web-components/src/components/file-uploader/demo-file-uploader.ts
@@ -1,0 +1,209 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2019, 2023
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, property, LitElement, customElement } from 'lit-element';
+
+import { delay } from 'bluebird';
+import { prefix } from '../../globals/settings';
+import ifNonNull from '../../globals/directives/if-non-null';
+import './file-uploader';
+import './drop-container';
+import {
+  FILE_UPLOADER_ITEM_SIZE,
+  FILE_UPLOADER_ITEM_STATE,
+} from './file-uploader-item';
+import { FileData } from './stories/types';
+
+/**
+ * A class to manage file uploading states, like sending file contents to server.
+ * DEMONSTRATION-PURPOSE ONLY.
+ * Data/state handling in file uploading tends to involve lots of application-specific logics
+ * and thus abstracting everything in a library won't be a good return on investment
+ * vs. letting users copy code here and implement features that fit their needs.
+ */
+@customElement(`${prefix}-ce-demo-file-uploader`)
+export default class BXCEDemoFileUploader extends LitElement {
+  /**
+   * The files being uploaded.
+   */
+  private _files: FileData[] = [];
+
+  /**
+   * Handles `bx-drop-container-changed` on `<cds-file-drop-container>`.
+   *
+   * @param event The event.
+   */
+  private _handleChange(event: CustomEvent) {
+    const { addedFiles } = event.detail;
+    const newFiles: FileData[] = addedFiles.map(
+      (item) =>
+        ({
+          id: Math.random().toString(36).slice(2),
+          file: item,
+          state: FILE_UPLOADER_ITEM_STATE.UPLOADING,
+        } as FileData)
+    );
+    const { multiple, _files: files, _simulateUpload: simulateUpload } = this;
+    if (multiple) {
+      this._files = files.concat(newFiles);
+      this.requestUpdate();
+      newFiles.forEach(simulateUpload, this);
+    } else if (addedFiles.length > 0) {
+      this._files = files.concat(newFiles[0]);
+      this.requestUpdate();
+      this._simulateUpload(newFiles[0]);
+    }
+  }
+
+  /**
+   * Handles `bx-file-uploader-item-deleted` on `<cds-file-uploader-item>`.
+   *
+   * @param event The event.
+   */
+  private _handleDelete(event: CustomEvent) {
+    const { fileId: idToDelete } = (event.target as HTMLElement).dataset;
+    this._files = this._files.filter(({ id }) => idToDelete !== id);
+    this.requestUpdate();
+  }
+
+  /**
+   * Simulates updating file.
+   *
+   * @param data The data of the file being uploaded.
+   */
+  private async _simulateUpload(data: FileData) {
+    const { id, file } = data;
+    if (file.size > 524288) {
+      this._files = this._files.map((item) =>
+        id !== item.id
+          ? item
+          : {
+              ...item,
+              state: FILE_UPLOADER_ITEM_STATE.EDITING,
+              invalid: true,
+              validityMessage: 'File size exceeds limit',
+              supplementalValidityMessage:
+                '500kb max file size. Select a new file and try again.',
+            }
+      );
+      this.requestUpdate();
+    } else {
+      // Simulates network request time
+      const rand = Math.random() * 1000;
+      await delay(rand);
+      this._files = this._files.map((item) =>
+        id !== item.id
+          ? item
+          : {
+              ...item,
+              state: FILE_UPLOADER_ITEM_STATE.UPLOADED,
+            }
+      );
+      this.requestUpdate();
+      // Shows x icon after 1 second
+      await delay(1000);
+      this._files = this._files.map((item) =>
+        id !== item.id
+          ? item
+          : {
+              ...item,
+              state: FILE_UPLOADER_ITEM_STATE.EDITING,
+            }
+      );
+      this.requestUpdate();
+    }
+  }
+
+  /**
+   * The file types the file input should accept, separated by space.
+   */
+  @property()
+  accept = '';
+
+  /**
+   * `true` if the drop container should be disabled.
+   */
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  /**
+   * The helper text.
+   */
+  @property({ attribute: 'helper-text' })
+  helperText = '';
+
+  /**
+   * The label text.
+   */
+  @property({ attribute: 'label-text' })
+  labelText = '';
+
+  /**
+   * `true` if the drop container should accept more than one files at once.
+   * Note that even with `false` set here, user _can_ select multiple files one by one.
+   */
+  @property({ type: Boolean, reflect: true })
+  multiple = false;
+
+  /**
+   * The size of the file uploader items.
+   */
+  @property({ reflect: true })
+  size = FILE_UPLOADER_ITEM_SIZE.REGULAR;
+
+  render() {
+    const {
+      accept,
+      disabled,
+      helperText,
+      labelText,
+      multiple,
+      size,
+      _files: files,
+      _handleChange: handleChange,
+      _handleDelete: handleDelete,
+    } = this;
+    return html`
+      <cds-file-uploader
+        helper-text="${ifNonNull(helperText)}"
+        label-text="${ifNonNull(labelText)}">
+        <cds-file-drop-container
+          accept="${ifNonNull(accept)}"
+          ?disabled="${disabled}"
+          ?multiple="${multiple}"
+          @bx-file-drop-container-changed="${handleChange}">
+          Drag and drop files here or click to upload
+        </cds-file-drop-container>
+        ${files.map(
+          ({
+            id,
+            invalid,
+            file,
+            state,
+            supplementalValidityMessage,
+            validityMessage,
+          }) => html`
+            <cds-file-uploader-item
+              data-file-id="${id}"
+              ?invalid="${invalid}"
+              size="${ifNonNull(size)}"
+              state="${ifNonNull(state)}"
+              validity-message="${ifNonNull(validityMessage)}"
+              @bx-file-uploader-item-deleted="${handleDelete}">
+              ${file.name}
+              <span slot="validity-message-supplement"
+                >${supplementalValidityMessage}</span
+              >
+            </cds-file-uploader-item>
+          `
+        )}
+      </cds-file-uploader>
+    `;
+  }
+}

--- a/packages/carbon-web-components/src/components/file-uploader/file-uploader-story.ts
+++ b/packages/carbon-web-components/src/components/file-uploader/file-uploader-story.ts
@@ -7,19 +7,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { html, property, LitElement } from 'lit-element';
-import { delay } from 'bluebird';
+import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
+import { prefix } from '../../globals/settings';
 import ifNonNull from '../../globals/directives/if-non-null';
 import './file-uploader';
 import './drop-container';
-import {
-  FILE_UPLOADER_ITEM_SIZE,
-  FILE_UPLOADER_ITEM_STATE,
-} from './file-uploader-item';
+import './demo-file-uploader';
+import { FILE_UPLOADER_ITEM_SIZE } from './file-uploader-item';
 import textNullable from '../../../.storybook/knob-text-nullable';
-import { FileData } from './stories/types';
 import storyDocs from './file-uploader-story.mdx';
 
 const sizes = {
@@ -35,217 +32,18 @@ const sizes = {
   //   FILE_UPLOADER_ITEM_SIZE.FIELD,
 };
 
-/**
- * A class to manage file uploading states, like sending file contents to server.
- * DEMONSTRATION-PURPOSE ONLY.
- * Data/state handling in file uploading tends to involve lots of application-specific logics
- * and thus abstracting everything in a library won't be a good return on investment
- * vs. letting users copy code here and implement features that fit their needs.
- */
-class BXCEDemoFileUploader extends LitElement {
-  /**
-   * The files being uploaded.
-   */
-  private _files: FileData[] = [];
-
-  /**
-   * Handles `bx-drop-container-changed` on `<cds-file-drop-container>`.
-   *
-   * @param event The event.
-   */
-  private _handleChange(event: CustomEvent) {
-    const { addedFiles } = event.detail;
-    const newFiles: FileData[] = addedFiles.map(
-      (item) =>
-        ({
-          id: Math.random().toString(36).slice(2),
-          file: item,
-          state: FILE_UPLOADER_ITEM_STATE.UPLOADING,
-        } as FileData)
-    );
-    const { multiple, _files: files, _simulateUpload: simulateUpload } = this;
-    if (multiple) {
-      this._files = files.concat(newFiles);
-      this.requestUpdate();
-      newFiles.forEach(simulateUpload, this);
-    } else if (addedFiles.length > 0) {
-      this._files = files.concat(newFiles[0]);
-      this.requestUpdate();
-      this._simulateUpload(newFiles[0]);
-    }
-  }
-
-  /**
-   * Handles `bx-file-uploader-item-deleted` on `<cds-file-uploader-item>`.
-   *
-   * @param event The event.
-   */
-  private _handleDelete(event: CustomEvent) {
-    const { fileId: idToDelete } = (event.target as HTMLElement).dataset;
-    this._files = this._files.filter(({ id }) => idToDelete !== id);
-    this.requestUpdate();
-  }
-
-  /**
-   * Simulates updating file.
-   *
-   * @param data The data of the file being uploaded.
-   */
-  private async _simulateUpload(data: FileData) {
-    const { id, file } = data;
-    if (file.size > 524288) {
-      this._files = this._files.map((item) =>
-        id !== item.id
-          ? item
-          : {
-              ...item,
-              state: FILE_UPLOADER_ITEM_STATE.EDITING,
-              invalid: true,
-              validityMessage: 'File size exceeds limit',
-              supplementalValidityMessage:
-                '500kb max file size. Select a new file and try again.',
-            }
-      );
-      this.requestUpdate();
-    } else {
-      // Simulates network request time
-      const rand = Math.random() * 1000;
-      await delay(rand);
-      this._files = this._files.map((item) =>
-        id !== item.id
-          ? item
-          : {
-              ...item,
-              state: FILE_UPLOADER_ITEM_STATE.UPLOADED,
-            }
-      );
-      this.requestUpdate();
-      // Shows x icon after 1 second
-      await delay(1000);
-      this._files = this._files.map((item) =>
-        id !== item.id
-          ? item
-          : {
-              ...item,
-              state: FILE_UPLOADER_ITEM_STATE.EDITING,
-            }
-      );
-      this.requestUpdate();
-    }
-  }
-
-  /**
-   * The file types the file input should accept, separated by space.
-   */
-  @property()
-  accept = '';
-
-  /**
-   * `true` if the drop container should be disabled.
-   */
-  @property({ type: Boolean, reflect: true })
-  disabled = false;
-
-  /**
-   * The helper text.
-   */
-  @property({ attribute: 'helper-text' })
-  helperText = '';
-
-  /**
-   * The label text.
-   */
-  @property({ attribute: 'label-text' })
-  labelText = '';
-
-  /**
-   * `true` if the drop container should accept more than one files at once.
-   * Note that even with `false` set here, user _can_ select multiple files one by one.
-   */
-  @property({ type: Boolean, reflect: true })
-  multiple = false;
-
-  /**
-   * The size of the file uploader items.
-   */
-  @property({ reflect: true })
-  size = FILE_UPLOADER_ITEM_SIZE.REGULAR;
-
-  render() {
-    const {
-      accept,
-      disabled,
-      helperText,
-      labelText,
-      multiple,
-      size,
-      _files: files,
-      _handleChange: handleChange,
-      _handleDelete: handleDelete,
-    } = this;
-    return html`
-      <cds-file-uploader
-        helper-text="${ifNonNull(helperText)}"
-        label-text="${ifNonNull(labelText)}">
-        <cds-file-drop-container
-          accept="${ifNonNull(accept)}"
-          ?disabled="${disabled}"
-          ?multiple="${multiple}"
-          @bx-file-drop-container-changed="${handleChange}">
-          Drag and drop files here or click to upload
-        </cds-file-drop-container>
-        ${files.map(
-          ({
-            id,
-            invalid,
-            file,
-            state,
-            supplementalValidityMessage,
-            validityMessage,
-          }) => html`
-            <cds-file-uploader-item
-              data-file-id="${id}"
-              ?invalid="${invalid}"
-              size="${ifNonNull(size)}"
-              state="${ifNonNull(state)}"
-              validity-message="${ifNonNull(validityMessage)}"
-              @bx-file-uploader-item-deleted="${handleDelete}">
-              ${file.name}
-              <span slot="validity-message-supplement"
-                >${supplementalValidityMessage}</span
-              >
-            </cds-file-uploader-item>
-          `
-        )}
-      </cds-file-uploader>
-    `;
-  }
-}
-
-const defineDemoFileUploader = (() => {
-  let hasDemoFileUploaderDefined;
-  return () => {
-    if (!hasDemoFileUploaderDefined) {
-      hasDemoFileUploaderDefined = true;
-      const ce = customElements;
-      // Prevents `web-component-analyzer` from harvesting `<cds-ce-demo-data-table>`
-      ce.define('bx-ce-demo-file-uploader', BXCEDemoFileUploader);
-    }
-  };
-})();
-
 export const Default = (args) => {
-  const { helperText, labelText } = args?.['bx-file-uploader'] ?? {};
-  const { accept, disabled, multiple } = args?.['bx-file-drop-container'] ?? {};
+  const { helperText, labelText } = args?.[`${prefix}-file-uploader`] ?? {};
+  const { accept, disabled, multiple } =
+    args?.[`${prefix}-file-drop-container`] ?? {};
   const { size, disableDelete, onBeforeDelete, onDelete } =
-    args?.['bx-file-uploader-item'] ?? {};
+    args?.[`${prefix}-file-uploader-item`] ?? {};
   const handleBeforeDelete = (event: CustomEvent) => {
     onBeforeDelete(event);
     if (disableDelete) {
       event.preventDefault();
     }
   };
-  defineDemoFileUploader();
   return html`
     <cds-ce-demo-file-uploader
       accept="${ifNonNull(accept)}"
@@ -267,14 +65,14 @@ export default {
   parameters: {
     ...storyDocs.parameters,
     knobs: {
-      'bx-file-uploader': () => ({
+      [`${prefix}-file-uploader`]: () => ({
         helperText: textNullable(
           'Helper text (helper-text)',
           'Only .jpg and .png files. 500kb max file size'
         ),
         labelText: textNullable('Label text (label-text)', 'Account photo'),
       }),
-      'bx-file-drop-container': () => ({
+      [`${prefix}-file-drop-container`]: () => ({
         accept: textNullable(
           'Accepted MIME types or file extensions (accept)',
           'image/jpeg image/png'
@@ -285,7 +83,7 @@ export default {
           true
         ),
       }),
-      'bx-file-uploader-item': () => ({
+      [`${prefix}-file-uploader-item`]: () => ({
         size: select('Filename height (size)', sizes, null),
         disableDelete: boolean(
           'Disable user-initiated delete action (Call event.preventDefault() in bx-file-uploader-item-beingdeleted event)',

--- a/packages/carbon-web-components/src/components/input/input.scss
+++ b/packages/carbon-web-components/src/components/input/input.scss
@@ -9,7 +9,7 @@ $css--plex: true !default;
 
 @use '@carbon/styles/scss/config' as *;
 @use '@carbon/styles/scss/spacing' as *;
-@use '@carbon/styles/scss/components/text-input/text-input';
+@use '@carbon/styles/scss/components/text-input/index';
 
 :host(#{$prefix}-input) {
   // the base text-input class has a 100% so we need to propagate it up to the host element

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -44,13 +44,16 @@
 
 // copying styles from
 :host(#{$prefix}-tab) {
-  display: contents;
+  display: flex;
+  background: transparent;
+  width: 100%;
 
   .#{$prefix}--tabs__nav-link {
     @include button-reset.reset($width: false);
     @include focus-outline('reset');
     @include type-style('body-compact-01');
 
+    width: 100%;
     overflow: hidden;
     max-width: 10rem;
     padding: $spacing-04 $spacing-05 $spacing-03;
@@ -71,6 +74,8 @@
 
   &[selected] {
     .#{$prefix}--tabs__nav-link {
+      @include type-style('heading-01');
+
       border-bottom: 2px solid $border-interactive;
     }
   }
@@ -84,7 +89,7 @@
     box-shadow: none;
   }
 
-  background-color: $background-hover;
+  background-color: transparent;
   box-shadow: 0 -1px 0 $background-hover;
 }
 
@@ -101,12 +106,6 @@
     + .#{$prefix}--tabs__nav-item.#{$prefix}--tabs__nav-item--selected,
     &.#{$prefix}--tabs__nav-item--selected + .#{$prefix}--tabs__nav-item {
       box-shadow: none;
-    }
-  }
-
-  &:hover {
-    @include breakpoint(md) {
-      background-color: $background-selected-hover;
     }
   }
 
@@ -137,7 +136,7 @@
 // which puts specificity of "specific" scenario though the style is for "regular" scenario
 :host(#{$prefix}-tab[disabled][role]),
 :host(#{$prefix}-tab[disabled][role]:hover) {
-  background-color: $layer-01;
+  background-color: transparent;
   box-shadow: none;
   cursor: not-allowed;
   outline: none;
@@ -149,17 +148,11 @@
   .#{$prefix}--tabs__nav-link {
     color: $tab-text-disabled;
     pointer-events: none;
+    outline: none;
 
     @include breakpoint(md) {
       border-bottom: $tab-underline-disabled;
     }
-  }
-}
-
-:host(#{$prefix}-tab[type='container'][disabled][role]),
-:host(#{$prefix}-tab[type='container'][disabled][role]:hover) {
-  @include breakpoint(md) {
-    background-color: $text-disabled;
   }
 }
 
@@ -171,12 +164,9 @@
 }
 
 :host(#{$prefix}-tab[selected]) {
-  background-color: $background-hover;
   transition: color $duration-fast-01 motion(standard, productive);
 
   &:hover {
-    background-color: $background-selected;
-
     @include breakpoint(md) {
       background-color: transparent;
     }
@@ -230,7 +220,6 @@
 
 :host(#{$prefix}-tab[highlighted]),
 :host(#{$prefix}-tab[highlighted]:hover) {
-  background-color: $background-hover;
   box-shadow: 0 -1px 0 $background-hover;
 
   // `highlighted` is not used in wide mode,
@@ -258,7 +247,7 @@
 :host(#{$prefix}-tab[disabled][in-focus][selected]),
 :host(#{$prefix}-tab[disabled][in-focus][selected]:hover) {
   display: flex;
-  background-color: $layer-01;
+  background-color: transparent;
   box-shadow: none;
 
   @include breakpoint(md) {

--- a/packages/carbon-web-components/src/components/tabs/tabs.scss
+++ b/packages/carbon-web-components/src/components/tabs/tabs.scss
@@ -12,11 +12,9 @@
 @use '@carbon/styles/scss/spacing' as *;
 @use '@carbon/styles/scss/motion' as *;
 @use '@carbon/styles/scss/type' as *;
-@use '@carbon/styles/scss/components/tabs' as *;
+@use '@carbon/styles/scss/components/tabs/index';
 @use '@carbon/styles/scss/components/tabs/vars' as *;
-
-// https://github.com/carbon-design-system/carbon/issues/11408
-@include tabs;
+@use '@carbon/styles/scss/utilities/button-reset';
 
 :host(#{$prefix}-tabs),
 :host(#{$prefix}-tabs-skeleton) {
@@ -44,20 +42,41 @@
   }
 }
 
-// TODO: deprecate
-// :host(#{$prefix}-tabs[type='container']) {
-//   @extend .#{$prefix}--tabs--container;
-// }
+// copying styles from
+:host(#{$prefix}-tab) {
+  display: contents;
 
-// :host(#{$prefix}-tab) {
-//   @extend .#{$prefix}--tabs__nav-item;
+  .#{$prefix}--tabs__nav-link {
+    @include button-reset.reset($width: false);
+    @include focus-outline('reset');
+    @include type-style('body-compact-01');
 
-//   outline: none;
+    overflow: hidden;
+    max-width: 10rem;
+    padding: $spacing-04 $spacing-05 $spacing-03;
+    border-bottom: $tab-underline-color;
+    color: $text-secondary;
+    text-align: left;
+    text-decoration: none;
+    text-overflow: ellipsis;
+    transition: border $duration-fast-01 motion(standard, productive),
+      outline $duration-fast-01 motion(standard, productive);
+    white-space: nowrap;
 
-//   .#{$prefix}--tabs__nav-link:active {
-//     @include focus-outline('reset');
-//   }
-// }
+    &:focus,
+    &:active {
+      @include focus-outline('outline');
+    }
+  }
+
+  &[selected] {
+    .#{$prefix}--tabs__nav-link {
+      border-bottom: 2px solid $border-interactive;
+    }
+  }
+
+  outline: none;
+}
 
 :host(#{$prefix}-tab:hover) {
   @include breakpoint(md) {

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -332,12 +332,7 @@ class BXTabs extends HostListenerMixin(BXContentSwitcher) {
   }
 
   render() {
-    const {
-      triggerContent,
-      _assistiveStatusText: assistiveStatusText,
-      _open: open,
-      _selectedItemContent: selectedItemContent,
-    } = this;
+    const { _assistiveStatusText: assistiveStatusText } = this;
     return html`
       <div id="tablist" role="tablist" class="${prefix}--tab--list">
         <slot></slot>

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -7,9 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { classMap } from 'lit-html/directives/class-map';
 import { html, property, query, customElement } from 'lit-element';
-import ChevronDown16 from '@carbon/icons/lib/chevron--down/16';
 import { prefix } from '../../globals/settings';
 import HostListenerMixin from '../../globals/mixins/host-listener';
 import HostListener from '../../globals/decorators/host-listener';

--- a/packages/carbon-web-components/src/components/tabs/tabs.ts
+++ b/packages/carbon-web-components/src/components/tabs/tabs.ts
@@ -338,32 +338,10 @@ class BXTabs extends HostListenerMixin(BXContentSwitcher) {
       _open: open,
       _selectedItemContent: selectedItemContent,
     } = this;
-    const triggerClasses = classMap({
-      [`${prefix}--tabs-trigger`]: true,
-      [`${prefix}--tabs-trigger--open`]: open,
-    });
-    const listClasses = classMap({
-      [`${prefix}--tabs__nav`]: true,
-      [`${prefix}--tabs__nav--hidden`]: !open,
-    });
     return html`
-      <div
-        id="trigger"
-        role="button"
-        class="${triggerClasses}"
-        aria-labelledby="trigger-label"
-        aria-expanded="${String(open)}"
-        aria-haspopup="listbox"
-        aria-owns="tablist"
-        aria-controls="tablist">
-        <span id="trigger-label" class="${prefix}--tabs-trigger-text">
-          ${selectedItemContent || triggerContent}
-        </span>
-        ${ChevronDown16({ 'aria-hidden': 'true' })}
-      </div>
-      <ul id="tablist" role="tablist" class="${listClasses}">
+      <div id="tablist" role="tablist" class="${prefix}--tab--list">
         <slot></slot>
-      </ul>
+      </div>
       <div
         class="${prefix}--assistive-text"
         role="status"

--- a/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
+++ b/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
@@ -51,7 +51,7 @@ class BXToggletip extends FocusMixin(LitElement) {
   }
 
   render() {
-    const { alignment, id, direction, open } = this;
+    const { alignment, id, open } = this;
     const classes = classMap({
       [`${prefix}--popover-container`]: true,
       [`${prefix}--popover--caret`]: true,

--- a/packages/carbon-web-components/src/index.ts
+++ b/packages/carbon-web-components/src/index.ts
@@ -104,7 +104,6 @@ export { default as BXTooltip } from './components/tooltip/tooltip';
 export { default as BXTooltipBody } from './components/tooltip/tooltip-body';
 export { default as BXTooltipDefinition } from './components/toggle-tip/toggletip';
 export { default as BXTooltipFooter } from './components/tooltip/tooltip-footer';
-export { default as BXTooltipIcon } from './components/tooltip/tooltip-icon';
 export { default as BXHeader } from './components/ui-shell/header';
 export { default as BXHeaderMenu } from './components/ui-shell/header-menu';
 export { default as BXHeaderMenuButton } from './components/ui-shell/header-menu-button';


### PR DESCRIPTION
### Related Ticket(s)
[#9991](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9991)
[#9988](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9988)
[#10011](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10011)

### Description
Fixed the styles for the Input and File uploader components.
The styles for the file uploader component seem to have retained its styles, but it might seem that functionality could be broken. Will need to investigate further/refactor later on.

As for the tabs component, in v11 there is no dropdown menu when in mobile view. 
Due to the individual tab styles are nested within the parent class, they are unable to be extended properly, thus the need to be copied into the current styles. When syncing to v11, we will also need to refactor this component slightly.

### Changelog

**New**

- new demo component to show off the file uploader
- styles are working for file uploader, input, and tabs

**Changed**

- importing the index file instead of the the specific `input` style file 
- separated the file uploader demo component due to the `define()` function not working within a story file

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
