### PR TITLE
fix(tooltip): remove tooltip-icon export

### DIFF
--- a/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
+++ b/packages/carbon-web-components/src/components/toggle-tip/toggletip.ts
@@ -12,7 +12,7 @@ import { html, property, customElement, LitElement } from 'lit-element';
 import Information16 from '@carbon/icons/lib/information/16';
 import { prefix } from '../../globals/settings';
 import FocusMixin from '../../globals/mixins/focus';
-import { TOOLTIP_ALIGNMENT, TOOLTIP_DIRECTION } from '../tooltip/defs';
+import { TOOLTIP_ALIGNMENT } from '../tooltip/defs';
 import styles from './toggletip.scss';
 
 /**
@@ -27,12 +27,6 @@ class BXToggletip extends FocusMixin(LitElement) {
    */
   @property()
   alignment = TOOLTIP_ALIGNMENT.TOP;
-
-  /**
-   * The tooltip direction.
-   */
-  @property()
-  direction = TOOLTIP_DIRECTION.BOTTOM;
 
   @property({ type: Boolean, reflect: true })
   open = false;
@@ -51,7 +45,7 @@ class BXToggletip extends FocusMixin(LitElement) {
   }
 
   render() {
-    const { alignment, id, direction, open } = this;
+    const { alignment, id, open } = this;
     const classes = classMap({
       [`${prefix}--popover-container`]: true,
       [`${prefix}--popover--caret`]: true,

--- a/packages/carbon-web-components/src/index.ts
+++ b/packages/carbon-web-components/src/index.ts
@@ -104,7 +104,6 @@ export { default as BXTooltip } from './components/tooltip/tooltip';
 export { default as BXTooltipBody } from './components/tooltip/tooltip-body';
 export { default as BXTooltipDefinition } from './components/toggle-tip/toggletip';
 export { default as BXTooltipFooter } from './components/tooltip/tooltip-footer';
-export { default as BXTooltipIcon } from './components/tooltip/tooltip-icon';
 export { default as BXHeader } from './components/ui-shell/header';
 export { default as BXHeaderMenu } from './components/ui-shell/header-menu';
 export { default as BXHeaderMenuButton } from './components/ui-shell/header-menu-button';


### PR DESCRIPTION
### Description

Removes unused enum and exports that were breaking the package builds.

### Changelog

**New**

- {{new thing}}

**Changed**

- {{changed thing}}

**Removed**

- `TOOLTIP_DIRECTION`
- `BXTooltipIcon` export

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
