### PR TITLE
fix(multiselect): update multiselect prefix and styles

### DIFF
--- a/packages/carbon-web-components/.storybook/_container.scss
+++ b/packages/carbon-web-components/.storybook/_container.scss
@@ -7,6 +7,8 @@
 // LICENSE file in the root directory of this source tree.
 //
 
+@use '@carbon/styles/scss/config' as *;
+@use '@carbon/styles/scss/utilities/convert' as *;
 @use '@carbon/styles/scss/utilities';
 @use '@carbon/styles/scss/fonts';
 @use '@carbon/styles/scss/theme' as *;
@@ -93,4 +95,10 @@ body,
   p {
     line-height: 20px;
   }
+}
+
+#{$prefix}-combo-box,
+#{$prefix}-dropdown,
+#{$prefix}-multi-select {
+  width: rem(300px);
 }

--- a/packages/carbon-web-components/.storybook/_container.scss
+++ b/packages/carbon-web-components/.storybook/_container.scss
@@ -96,9 +96,3 @@ body,
     line-height: 20px;
   }
 }
-
-#{$prefix}-combo-box,
-#{$prefix}-dropdown,
-#{$prefix}-multi-select {
-  width: rem(300px);
-}

--- a/packages/carbon-web-components/src/components/combo-box/combo-box-story.ts
+++ b/packages/carbon-web-components/src/components/combo-box/combo-box-story.ts
@@ -101,6 +101,10 @@ export const Default = (args) => {
   `;
 };
 
+Default.decorators = [
+  (story) => html` <div style="width:300px">${story()}</div> `,
+];
+
 Default.storyName = 'Default';
 
 export default {

--- a/packages/carbon-web-components/src/components/dropdown/dropdown-story.ts
+++ b/packages/carbon-web-components/src/components/dropdown/dropdown-story.ts
@@ -97,6 +97,10 @@ export const Default = (args) => {
   `;
 };
 
+Default.decorators = [
+  (story) => html` <div style="width:300px">${story()}</div> `,
+];
+
 Default.storyName = 'Default';
 
 Default.parameters = {

--- a/packages/carbon-web-components/src/components/multi-select/multi-select-story.ts
+++ b/packages/carbon-web-components/src/components/multi-select/multi-select-story.ts
@@ -112,6 +112,10 @@ export const Default = (args) => {
   `;
 };
 
+Default.decorators = [
+  (story) => html` <div style="width:300px">${story()}</div> `,
+];
+
 Default.storyName = 'Default';
 
 export const Filterable = (args) => {
@@ -188,6 +192,10 @@ export const Filterable = (args) => {
     </cds-multi-select>
   `;
 };
+
+Filterable.decorators = [
+  (story) => html` <div style="width:300px">${story()}</div> `,
+];
 
 Filterable.storyName = 'Filterable';
 

--- a/packages/carbon-web-components/src/components/multi-select/multi-select-story.ts
+++ b/packages/carbon-web-components/src/components/multi-select/multi-select-story.ts
@@ -11,6 +11,7 @@ import { html } from 'lit-element';
 import { action } from '@storybook/addon-actions';
 import { boolean, select } from '@storybook/addon-knobs';
 import textNullable from '../../../.storybook/knob-text-nullable';
+import { prefix } from '../../globals/settings';
 import ifNonNull from '../../globals/directives/if-non-null';
 import {
   DROPDOWN_COLOR_SCHEME,
@@ -59,7 +60,7 @@ export const Default = (args) => {
     onBeforeToggle,
     onSelect,
     onToggle,
-  } = args?.['bx-multi-select'] ?? {};
+  } = args?.[`${prefix}-multi-select`] ?? {};
   const handleBeforeSelect = (event: CustomEvent) => {
     if (onBeforeSelect) {
       onBeforeSelect(event);
@@ -92,10 +93,14 @@ export const Default = (args) => {
       type=${ifNonNull(type)}
       validity-message=${ifNonNull(validityMessage)}
       value="${ifNonNull(value)}"
-      @bx-multi-select-beingselected=${handleBeforeSelect}
-      @bx-multi-select-beingtoggled=${handleBeforeToggle}
-      @bx-multi-select-selected=${onSelect}
-      @bx-multi-select-toggled=${onToggle}>
+      @cds-multi-select-beingselected=${handleBeforeSelect}
+      @cds-multi-select-beingtoggled=${handleBeforeToggle}
+      @cds-multi-select-selected=${onSelect}
+      @cds-multi-select-toggled=${onToggle}>
+      <cds-multi-select-item value="example"
+        >An example option that is really long to show what should be done to
+        handle long text</cds-multi-select-item
+      >
       <cds-multi-select-item value="all">Option 1</cds-multi-select-item>
       <cds-multi-select-item value="cloudFoundry"
         >Option 2</cds-multi-select-item
@@ -131,7 +136,7 @@ export const Filterable = (args) => {
     onBeforeToggle,
     onSelect,
     onToggle,
-  } = args?.['bx-multi-select'] ?? {};
+  } = args?.[`${prefix}-multi-select`] ?? {};
   const handleBeforeSelect = (event: CustomEvent) => {
     if (onBeforeSelect) {
       onBeforeSelect(event);
@@ -165,10 +170,10 @@ export const Filterable = (args) => {
       type=${ifNonNull(type)}
       validity-message=${ifNonNull(validityMessage)}
       value="${ifNonNull(value)}"
-      @bx-multi-select-beingselected=${handleBeforeSelect}
-      @bx-multi-select-beingtoggled=${handleBeforeToggle}
-      @bx-multi-select-selected=${onSelect}
-      @bx-multi-select-toggled=${onToggle}>
+      @cds-multi-select-beingselected=${handleBeforeSelect}
+      @cds-multi-select-beingtoggled=${handleBeforeToggle}
+      @cds-multi-select-selected=${onSelect}
+      @cds-multi-select-toggled=${onToggle}>
       <cds-multi-select-item value="example"
         >An example option that is really long to show what should be done to
         handle long text</cds-multi-select-item
@@ -191,7 +196,7 @@ export default {
   parameters: {
     ...storyDocs.parameters,
     knobs: {
-      'bx-multi-select': () => ({
+      [`${prefix}-multi-select`]: () => ({
         clearSelectionLabel: textNullable(
           'a11y label for the icon to clear selection (clear-selection-label)',
           ''
@@ -224,17 +229,17 @@ export default {
           ''
         ),
         disableSelection: boolean(
-          'Disable user-initiated selection change (Call event.preventDefault() in bx-multi-select-beingselected event)',
+          `Disable user-initiated selection change (Call event.preventDefault() in ${prefix}-multi-select-beingselected event)`,
           false
         ),
         disableToggle: boolean(
-          'Disable user-initiated toggle of open state (Call event.preventDefault() in bx-multi-select-beingtoggled event)',
+          `Disable user-initiated toggle of open state (Call event.preventDefault() in ${prefix}-multi-select-beingtoggled event)`,
           false
         ),
-        onBeforeSelect: action('bx-multi-select-beingselected'),
-        onBeforeToggle: action('bx-multi-select-beingtoggled'),
-        onSelect: action('bx-multi-select-selected'),
-        onToggle: action('bx-multi-select-toggled'),
+        onBeforeSelect: action(`${prefix}-multi-select-beingselected`),
+        onBeforeToggle: action(`${prefix}-multi-select-beingtoggled`),
+        onSelect: action(`${prefix}-multi-select-selected`),
+        onToggle: action(`${prefix}-multi-select-toggled`),
       }),
     },
   },

--- a/packages/carbon-web-components/src/components/multi-select/multi-select.scss
+++ b/packages/carbon-web-components/src/components/multi-select/multi-select.scss
@@ -34,6 +34,7 @@ $css--plex: true !default;
 
   .#{$prefix}--text-input {
     border: none;
+    padding-left: 0;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9996

### Description

This PR updates the multiselect component to use the Carbon v11 prefix. It also includes a small spacing update for the filterable multiselect and default widths for the storybook listbox components. The spacing issues with the multiselect items should be addressed in the larger v2 sync (issues explained further here https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/9996#issuecomment-1442136720)


### Changelog

**Changed**

- v11 prefixes
- filterable multiselect input spacing
- storybook listbox widths

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
