### PR TITLE
fix(skeleton-text): implement skeleton line generator

### DIFF
--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text-story.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text-story.ts
@@ -46,10 +46,6 @@ export const Lines = (args) => {
   `;
 };
 
-Lines.decorators = [
-  (story) => html` <div style="width:300px">${story()}</div> `,
-];
-
 Lines.parameters = {
   knobs: {
     [`${prefix}-skeleton-text`]: () => ({
@@ -57,7 +53,7 @@ Lines.parameters = {
       lineCount: number('The number of lines in a paragraph (lineCount)', 3),
       width: text(
         'Width (in px or %) of single line of text or max-width of paragraph lines (width)',
-        '500px'
+        '100%'
       ),
     }),
   },

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text-story.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text-story.ts
@@ -8,8 +8,9 @@
  */
 
 import { html } from 'lit-element';
-import { select } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 import ifNonNull from '../../globals/directives/if-non-null';
+import { prefix } from '../../globals/settings';
 import { SKELETON_TEXT_TYPE } from './skeleton-text';
 import storyDocs from './skeleton-text-story.mdx';
 
@@ -19,31 +20,48 @@ const types = {
 };
 
 export const Default = (args) => {
-  const { type } = args?.['bx-skeleton-text'] ?? {};
+  const { type } = args?.[`${prefix}-skeleton-text`] ?? {};
   return html`
     <cds-skeleton-text type="${ifNonNull(type)}"></cds-skeleton-text>
   `;
 };
 
-Default.storyName = 'Default';
-
 Default.parameters = {
   knobs: {
-    'bx-skeleton-text': () => ({
+    [`${prefix}-skeleton-text`]: () => ({
       type: select('Skeleton text type (type)', types, null),
     }),
   },
 };
 
-export const lines = () => html`
-  <cds-skeleton-text type="line"></cds-skeleton-text>
-  <cds-skeleton-text type="line"></cds-skeleton-text>
-  <cds-skeleton-text type="line"></cds-skeleton-text>
-`;
+export const Lines = (args) => {
+  const { paragraph, lineCount, width } =
+    args?.[`${prefix}-skeleton-text`] ?? {};
+  return html`
+    <cds-skeleton-text
+      type="line"
+      ?paragraph="${paragraph}"
+      lineCount="${lineCount}"
+      width="${width}"></cds-skeleton-text>
+  `;
+};
 
-lines.decorators = [
+Lines.decorators = [
   (story) => html` <div style="width:300px">${story()}</div> `,
 ];
+
+Lines.parameters = {
+  knobs: {
+    [`${prefix}-skeleton-text`]: () => ({
+      paragraph: boolean('Use multiple lines of text (paragraph)', true),
+      lineCount: number('The number of lines in a paragraph (lineCount)', 3),
+      width: text(
+        'Width (in px or %) of single line of text or max-width of paragraph lines (width)',
+        '500px'
+      ),
+    }),
+  },
+};
 
 export default {
   title: 'Components/Skeleton text',

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.scss
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.scss
@@ -12,15 +12,3 @@
   display: block;
   width: 100%;
 }
-
-:host(#{$prefix}-skeleton-text[type='line']:nth-of-type(1n)) {
-  width: calc(100% - 73px);
-}
-
-:host(#{$prefix}-skeleton-text[type='line']:nth-of-type(2n)) {
-  width: calc(100% - 11px);
-}
-
-:host(#{$prefix}-skeleton-text[type='line']:nth-of-type(3n)) {
-  width: calc(100% - 43px);
-}

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
@@ -66,7 +66,7 @@ class BXSkeletonText extends LitElement {
       return html`${lines.map((_, i) => {
         const randomWidth =
           (widthPercent && `${getRandomInt(0, 75, i)}px`) ||
-          (widthPx && `${getRandomInt(widthNum - 75, widthNum, i)}px`);
+          (widthPx && `${getRandomInt(0, widthNum, i)}px`);
         const style =
           (widthPercent && `width: calc(${width} - ${randomWidth})`) ||
           (widthPx && `width: ${randomWidth}`) ||

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
@@ -34,14 +34,21 @@ class BXSkeletonText extends LitElement {
   type = SKELETON_TEXT_TYPE.REGULAR;
 
   /**
-   * width of line
+   * width (in px or %) of single line of text or max-width of paragraph lines
    */
   @property({ reflect: true })
   width = '100%';
 
+  /**
+   * will generate multiple lines of text
+   */
+
   @property({ type: Boolean, reflect: true })
   paragraph = false;
 
+  /**
+   * the number of lines in a paragraph
+   */
   @property({ type: Number, reflect: true })
   lineCount = 3;
 

--- a/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
+++ b/packages/carbon-web-components/src/components/skeleton-text/skeleton-text.ts
@@ -15,10 +15,15 @@ import styles from './skeleton-text.scss';
 
 export { SKELETON_TEXT_TYPE };
 
+function getRandomInt(min: number, max: number, n: number) {
+  const randoms = [0.973051493507435, 0.15334737213558558, 0.5671034553053769];
+  return Math.floor(randoms[n % 3] * (max - min + 1)) + min;
+}
+
 /**
  * Skeleton text.
  *
- * @element bx-skeleton-text
+ * @element cds-skeleton-text
  */
 @customElement(`${prefix}-skeleton-text`)
 class BXSkeletonText extends LitElement {
@@ -28,13 +33,42 @@ class BXSkeletonText extends LitElement {
   @property({ reflect: true })
   type = SKELETON_TEXT_TYPE.REGULAR;
 
+  /**
+   * width of line
+   */
+  @property({ reflect: true })
+  width = '100%';
+
+  @property({ type: Boolean, reflect: true })
+  paragraph = false;
+
+  @property({ type: Number, reflect: true })
+  lineCount = 3;
+
   render() {
-    const { type } = this;
+    const { paragraph, lineCount, type, width } = this;
     const classes = classMap({
       [`${prefix}--skeleton__text`]: true,
       [`${prefix}--skeleton__heading`]: type === SKELETON_TEXT_TYPE.HEADING,
     });
-    return html` <p class="${classes}"></p> `;
+    if (paragraph) {
+      const widthNum = parseInt(this.width, 10);
+      const widthPx = this.width.includes('px');
+      const widthPercent = this.width.includes('%');
+      const lines = Array.apply(null, Array(lineCount));
+      return html`${lines.map((_, i) => {
+        const randomWidth =
+          (widthPercent && `${getRandomInt(0, 75, i)}px`) ||
+          (widthPx && `${getRandomInt(widthNum - 75, widthNum, i)}px`);
+        const style =
+          (widthPercent && `width: calc(${width} - ${randomWidth})`) ||
+          (widthPx && `width: ${randomWidth}`) ||
+          '';
+        return html`<p class="${classes}" style="${style}"></p>`;
+      })}`;
+    }
+
+    return html`<p class="${classes}" style="width:${width}"></p>`;
   }
 
   static styles = styles;


### PR DESCRIPTION
### Related Ticket(s)

https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/10007

### Description

This PR updates the skeleton text component to match the Carbon v11 version. The storybook example is updated to show the new line generator which should match the v11 version as well

### Changelog

**New**

- `paragraph`, `linecount`, and `width` properties

**Changed**

- update v11 prefix

**Removed**

- fixed line widths

<!-- React and Web Component deploy previews are enabled by default. -->
<!-- To enable additional available deploy previews, apply the following -->
<!-- labels for the corresponding package: -->
<!-- *** "test: e2e": Codesandbox examples and e2e integration tests -->
<!-- *** "package: services": Services -->
<!-- *** "package: utilities": Utilities -->
<!-- *** "RTL": React / Web Components (RTL) -->
<!-- *** "feature flag": React / Web Components (experimental) -->
